### PR TITLE
Update address of code of conduct

### DIFF
--- a/scripts/code-of-conduct.coffee
+++ b/scripts/code-of-conduct.coffee
@@ -25,4 +25,4 @@ module.exports = (robot) ->
   robot.hear regex, (msg) ->
     msg.send "Ei <@#{msg.envelope.user.id}>. *#{msg.match[1]}* não é legal de se falar por aqui. " +
              "Depois dá uma conferida no Código de Conduta do grupo :wink:"
-    msg.send "https://github.com/iOSDevBR/Codigo-De-Conduta"
+    msg.send "https://github.com/androiddevbr/codigo-de-conduta"


### PR DESCRIPTION
Hubot was answering with iOSDevBR address, this patch changes it to AndroidDevBR code of conduct.
